### PR TITLE
Make sure to read whole response stream

### DIFF
--- a/src/Josser/Client/Transport/Guzzle5Transport.php
+++ b/src/Josser/Client/Transport/Guzzle5Transport.php
@@ -60,7 +60,7 @@ class Guzzle5Transport implements TransportInterface
                     'Content-Type' => 'application/json',
                 ]
             ]);
-            return $response->getBody()->getContents();
+            return (string) $response->getBody();
         } catch (\Exception $e) {
             $error = sprintf('JSON-RPC http connection failed. Remote service at "%s" is not responding.', $this->guzzle->getBaseUrl());
             throw new TransportFailureException($error, null, $e);

--- a/src/Josser/Client/Transport/Guzzle6Transport.php
+++ b/src/Josser/Client/Transport/Guzzle6Transport.php
@@ -60,7 +60,7 @@ class Guzzle6Transport implements TransportInterface
                     'Content-Type' => 'application/json',
                 ]
             ]);
-            return $response->getBody()->getContents();
+            return (string) $response->getBody();
         } catch (\Exception $e) {
             $error = sprintf('JSON-RPC http connection failed. Remote service at "%s" is not responding.', $this->guzzle->getConfig('base_uri'));
             throw new TransportFailureException($error, null, $e);


### PR DESCRIPTION
Hi Alan, I like your json-rpc library very much, because it decouples the protocol (so I can extend it to be able to talk to an API that's not strictly json-rpc1 nor json-rpc2) and als decouples the transport so I can reuse the transport for other web requests and attach a logger that will work for all kinds requests. Features I could not find in other PHP json-rpc libraries, many thanks for this! I have found only two minor inconveniences for which I provide you pull requests.

This first PR ensures to read out full Guzzle response streams. For example when you debug log the full response first using a Guzzle Middleware::log handler the Josser client later receives an empty response because the response stream pointer will already be at the end of the stream.