### PR TITLE
Allow URI of web service to be set on the Guzzle transports

### DIFF
--- a/src/Josser/Client/Transport/Guzzle5Transport.php
+++ b/src/Josser/Client/Transport/Guzzle5Transport.php
@@ -29,11 +29,20 @@ class Guzzle5Transport implements TransportInterface
     private $guzzle;
 
     /**
-     * @param Client $guzzle
+     * URI of the web service, or null to use the base_uri of the Guzzle http client.
+     *
+     * @var string|null
      */
-    public function __construct(Client $guzzle)
+    private $uri;
+
+    /**
+     * @param Client $guzzle
+     * @param string|null $uri URL of the web service, or null to use the base_uri of $guzzle
+     */
+    public function __construct(Client $guzzle, $uri = null)
     {
         $this->guzzle = $guzzle;
+        $this->uri = $uri;
     }
 
     /**
@@ -54,7 +63,7 @@ class Guzzle5Transport implements TransportInterface
     public function send($data)
     {
         try {
-            $response = $this->guzzle->post(null, [
+            $response = $this->guzzle->post($this->uri, [
                 'body' => $data,
                 'headers' => [
                     'Content-Type' => 'application/json',

--- a/src/Josser/Client/Transport/Guzzle6Transport.php
+++ b/src/Josser/Client/Transport/Guzzle6Transport.php
@@ -29,11 +29,20 @@ class Guzzle6Transport implements TransportInterface
     private $guzzle;
 
     /**
-     * @param Client $guzzle
+     * URI of the web service, or null to use the base_uri of the Guzzle http client.
+     *
+     * @var string|null
      */
-    public function __construct(Client $guzzle)
+    private $uri;
+
+    /**
+     * @param Client $guzzle
+     * @param string|null $uri URL of the web service, or null to use the base_uri of $guzzle
+     */
+    public function __construct(Client $guzzle, $uri = null)
     {
         $this->guzzle = $guzzle;
+        $this->uri = $uri;
     }
 
     /**
@@ -54,7 +63,7 @@ class Guzzle6Transport implements TransportInterface
     public function send($data)
     {
         try {
-            $response = $this->guzzle->request('POST', null, [
+            $response = $this->guzzle->request('POST', $this->uri, [
                 'body' => $data,
                 'headers' => [
                     'Content-Type' => 'application/json',


### PR DESCRIPTION
Hi Alan, this second PR concerns where the URI of a web service over HTTP can be configured. Currently the Guzzle transport implementations rely on the base_uri of the Guzzle clients used. A downside of this is that this makes the Guzzle clients less reusable for other communications (or binding to multiple RPC clients). With these backwards compatible changes you can configure the URI on the Guzzle transport implementations instead if you want.