### PR TITLE
Typed format for symfony/serializer^5.0 and PHP 7.4 for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
+  - 7.4
 
 before_script:
   - wget http://getcomposer.org/composer.phar

--- a/src/Josser/Client.php
+++ b/src/Josser/Client.php
@@ -20,6 +20,7 @@ use Josser\Client\Transport\TransportInterface;
 use Josser\Exception\RequestResponseMismatchException;
 use Josser\Client\Request\Request;
 use Josser\Client\Request\Notification;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
 
 /**
  * JSON-RPC client.
@@ -104,14 +105,14 @@ class Client
         }
 
         $requestDTO = $protocol->getRequestDataTransferObject($request);
-        $encodedRequest = $protocol->getEncoder()->encode($requestDTO, null);
+        $encodedRequest = $protocol->getEncoder()->encode($requestDTO, JsonEncoder::FORMAT);
         $encodedResponse = $transport->send($encodedRequest);
 
         if($protocol->isNotification($request)) {
             return new NoResponse();
         }
 
-        $responseDTO = $protocol->getDecoder()->decode($encodedResponse, null);
+        $responseDTO = $protocol->getDecoder()->decode($encodedResponse, JsonEncoder::FORMAT);
         $response = $protocol->createResponse($responseDTO);
 
         if(!$protocol->match($request, $response)) {


### PR DESCRIPTION
From `symfony/serializer:^5.0` encode's method `$format` argument is typed as `string`